### PR TITLE
Fix mobile layout spacing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -61,11 +61,11 @@ section:first-of-type {                /* logo + 1ª seção  */
 /*  MOBILE (≤576 px) – reduzimos os respiros  */
 @media (max-width: 576px) {
   main {
-    gap: var(--space-sm);              /* 1.5 rem           */
+    gap: 1rem;
     padding-bottom: var(--space-sm);
   }
 
   section {
-    padding-block: var(--space-sm);    /* 1.5 rem           */
+    padding-block: 0;
   }
 }

--- a/src/components/bloco-cases/BlocoCases.css
+++ b/src/components/bloco-cases/BlocoCases.css
@@ -15,9 +15,9 @@
 /* MOBILE */
 @media (max-width: 576px){
   .bloco-cases{
-    margin-block: var(--space-sm);    /* 1.5 rem          */
+    margin: 0.9rem auto 1.5rem;
   }
   .bloco-cases img{
-    border-radius:16px;
+    border-radius:20px;
   }
 }

--- a/src/components/section-title/section-title.css
+++ b/src/components/section-title/section-title.css
@@ -59,21 +59,21 @@
     flex-direction: column;
     align-items: center;
     text-align: center;
-    gap: 0.25rem;  
-    margin: 2rem auto 1.25rem; 
-    margin-block-end: var(--space-sm);   /* 1.5 rem */
+    margin-bottom: 0.8rem;
   }
 
   .label-pill{
-    padding: 10px 18px;
-    font-size: 1rem;
-    white-space: normal;                 /* quebra em 2 linhas */
+    display: block;
+    width: 100%;
+    max-width: 320px;
+    padding: 12px 20px;
+    white-space: normal;
     line-height: 1.25;
-    border-radius: 8px;
+    border-radius: 14px;
   }
 
   .section-title-wrapper .subtitle {
-    max-width: 24ch;
-    margin: 0.4rem auto 0;       /* perto do título                     */
+    max-width: 30ch;
+    margin-top: 0.4rem;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -58,16 +58,20 @@ img {
 @media (max-width: 576px) {
 
   /* 1 ▪ afasta menos as seções principais ----------------------- */
-  main            { gap: 1.2rem; }      /* antes 1.75-2rem */
+  main            { gap: 1rem; }
 
   /* 2 ▪ bloco TÍTULO + subtítulo ------------------------------- */
   .section-title-wrapper        { margin-bottom: 0.8rem; } /* cola no bloco roxo */
 
   .label-pill {
-    width: 100%;                  /* pílula ocupa a largura da arte     */
-    max-width: 320px;             /* …mas não estoura                   */
+    display: block;
+    width: 100%;
+    max-width: 320px;
     text-align: center;
     padding: 12px 20px;
+    border-radius: 14px;
+    white-space: normal;
+    line-height: 1.25;
   }
 
   .section-title-wrapper .subtitle {
@@ -77,7 +81,7 @@ img {
   }
 
   /* 3 ▪ bloco roxo (cards) logo depois do subtítulo ------------- */
-  .bloco-cases       { margin-top: 0.9rem; }  /* cola bem mais        */
+  .bloco-cases       { margin: 0.9rem auto 1.5rem; }
   .bloco-cases img   { border-radius: 20px; }
 
   /* 4 ▪ tira “buracos” extras causados por <section> ------------ */


### PR DESCRIPTION
## Summary
- tighten section padding and gaps on small screens
- center section titles and prevent label wrapping
- adjust bloco-cases spacing

## Testing
- `yarn dev` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68604b946e30832884844e2ed9e0a4fd