### PR TITLE
Fix SectionTitle subtitle layout for desktop

### DIFF
--- a/src/components/section-title/section-title.css
+++ b/src/components/section-title/section-title.css
@@ -20,11 +20,21 @@
 }
 
 .section-title-wrapper .subtitle {
-  flex: 1 1 40ch;           
+  flex: 1 1 40ch;
   font-size: var(--fs-sub);
   font-weight: 400;
   line-height: 1.4;
   max-width: 500px;
+}
+
+@media (min-width: 769px) {
+  .section-title-wrapper .subtitle {
+    margin-left: 1rem;
+    max-width: 34ch;
+    display: inline-block;
+    transform: translateY(4px);
+    flex: 0 1 auto;
+  }
 }
 .label-pill {
   display: inline-block;


### PR DESCRIPTION
## Summary
- tweak desktop layout of `SectionTitle` subtitle so it lines up with the label pill

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860504763f48328a815e445d5afbd31