### PR TITLE
Add cases card markup and styles

### DIFF
--- a/src/components/bloco-cases/BlocoCases.css
+++ b/src/components/bloco-cases/BlocoCases.css
@@ -5,6 +5,18 @@
   margin: 2rem auto 4rem;
 }
 
+.cases-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cases-card .divider {
+  width: 1px;
+  background: #7954ff;
+  margin: 0 3rem;
+}
+
 .bloco-cases img{
   display:block;
   width:100%;

--- a/src/components/bloco-cases/BlocoCases.tsx
+++ b/src/components/bloco-cases/BlocoCases.tsx
@@ -2,7 +2,7 @@ import blocoCases from "../../assets/bloco-cases.png";
 import "./BlocoCases.css";
 
 const BlocoCases: React.FC = () => (
-  <figure className="bloco-cases">
+  <figure className="bloco-cases cases-card">
     <img src={blocoCases} alt="Big Pictures: Deus, Jesus e Espírito Santo" />
   </figure>
 );


### PR DESCRIPTION
## Summary
- add `cases-card` class to BlocoCases markup
- style desktop `.cases-card` and `.cases-card .divider`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686052f656c88328b446e9452ebc68a8